### PR TITLE
Clean up EHVI imports

### DIFF
--- a/al_pipeline/selection/ehvi.py
+++ b/al_pipeline/selection/ehvi.py
@@ -1,13 +1,7 @@
 import numpy as np
 from scipy.stats import norm
-from scipy.special import ndtr  # This is equivalent to the CDF of the normal distribution (Phi)
-import torch
-import gpytorch
 
-
-# The module relies on numpy and SciPy's normal distribution utilities.
-import numpy as np
-from scipy.stats import norm
+__doc__ = """Utility helpers for expected hypervolume improvement calculations."""
 
 
 def exipsi_vectorized(a, b, m, s):


### PR DESCRIPTION
## Summary
- remove the duplicated numpy/scipy import block in the EHVI helper module and drop unused imports
- add a concise module docstring highlighting the EHVI utilities

## Testing
- ruff check --select F401 al_pipeline/selection/ehvi.py

------
https://chatgpt.com/codex/tasks/task_e_68cc57e1970483259cc7794ce1e307c3