### PR TITLE
Remove unused dependencies from label generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ from al_pipeline.features import SequenceFeaturizer
 featurizer = SequenceFeaturizer(model_name="mpipi", db_path="/path/to/database")
 ```
 
+## Label Generation Dependencies
+
+The label generation utility (`al_pipeline.labels.generate_labels`) now depends
+only on `pandas` in addition to the Python standard library. This allows the
+script to run in lighter environments where `numpy` and `matplotlib` are not
+available.
+
 ## Slurm Usage
 
 Submit the pipeline as a batch job:

--- a/al_pipeline/labels/generate_labels.py
+++ b/al_pipeline/labels/generate_labels.py
@@ -1,7 +1,4 @@
-import numpy as np
-import matplotlib.pyplot as plt
 import pandas as pd
-import os
 import argparse
 
 def main():


### PR DESCRIPTION
## Summary
- remove unused numpy, matplotlib, and os imports from the label generation script
- document that the label generation utility now only depends on pandas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc5ab907a48325bd98f18e7533502d